### PR TITLE
Fix DLL's on Cygwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ init:
 	cd build; \
 	cmake -DCMAKE_INSTALL_PREFIX=../installed -DBUILD_GUI=OFF ..; \
 	make -j2 || exit 2; \
+	make install; \
 	cd ../../; \
 	mkdir bin; \
 	cd bin; \


### PR DESCRIPTION
There was a compilation issue on Andrew's fresh copy of Cygwin, because mine had an extra modification to the $PATH environment variable.  This commit will hopefully fix Cygwin DLL issues so they don't return.

Another PR will be necessary to fix the Eigen dependency by bundling the header files, most likely through a mofid-data repo.