### PR TITLE
Enhance Build System: Remove GCC-11 Mandate & Upgrade to C++17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test:
 	cd $(mofid-dir); \
 	mkdir bin; \
 	cd bin; \
-	cmake -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DOpenBabel3_DIR=../openbabel/build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON ../src/; \
+	cmake -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DOpenBabel3_DIR=../openbabel/build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON ../src/; \
 	make -j$$(nproc); \
 
 unittest:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 mofid-dir := $(shell pwd)
 python-packages-dir := $(shell python -m site | grep -o "/.*/site-packages" | head --lines 1) 
 
+# Default compilers; can be overridden from the environment (e.g. via loaded gcc modules)
+CC ?= gcc
+CXX ?= g++
+
 all:
 	@echo "Sample make file for experimentation.  Still needs work.  Only backup implemented"
 
@@ -47,7 +51,7 @@ test:
 	cd openbabel; \
 	mkdir build installed; \
 	cd build; \
-	cmake -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_INSTALL_PREFIX=../installed -DBUILD_GUI=OFF -DENABLE_TESTS=OFF -DEIGEN3_INCLUDE_DIR=../eigen -DRUN_SWIG=ON -DPYTHON_BINDINGS=ON ..; \
+	cmake -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_INSTALL_PREFIX=../installed -DBUILD_GUI=OFF -DENABLE_TESTS=OFF -DEIGEN3_INCLUDE_DIR=../eigen -DRUN_SWIG=ON -DPYTHON_BINDINGS=ON ..; \
 	make -j$$(nproc) || exit 2; \
 	make install; \
 	cd $(python-packages-dir); \
@@ -72,28 +76,31 @@ init:
 	cd openbabel; \
 	mkdir build installed; \
 	cd build; \
-	cmake -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_INSTALL_PREFIX=../installed -DENABLE_TESTS=OFF -DBUILD_GUI=OFF -DEIGEN3_INCLUDE_DIR=../eigen ..; \
+	cmake -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_INSTALL_PREFIX=../installed -DENABLE_TESTS=OFF -DBUILD_GUI=OFF -DEIGEN3_INCLUDE_DIR=../eigen ..; \
 	make -j$$(nproc) || exit 2; \
 	make install; \
 	cd $(mofid-dir); \
 	mkdir bin; \
 	cd bin; \
-	cmake -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DOpenBabel3_DIR=../openbabel/build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ../src/; \
+	cmake -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DOpenBabel3_DIR=../openbabel/build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ../src/; \
 	make -j$$(nproc)
 	# Sets up all the cmake details, so that usage is as simple as
 	# `bin/sbu MOF.cif` and re-compilation is as easy as `make exe`
+
+clean-init:
+	rm -rf openbabel/build openbabel/installed bin
 
 debug:
 	cd openbabel; \
 	mkdir build installed; \
 	cd build; \
-	cmake -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_INSTALL_PREFIX=../installed -DBUILD_GUI=OFF -DENABLE_TESTS=OFF -DEIGEN3_INCLUDE_DIR=../eigen ..; \
+	cmake -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_INSTALL_PREFIX=../installed -DBUILD_GUI=OFF -DENABLE_TESTS=OFF -DEIGEN3_INCLUDE_DIR=../eigen ..; \
 	make -j$$(nproc) || exit 2; \
 	make install; \
 	cd $(mofid-dir); \
 	mkdir bin; \
 	cd bin; \
-	cmake -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DOpenBabel3_DIR=../openbabel/build ../src/ -DCMAKE_BUILD_TYPE=Debug;\
+	cmake -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DOpenBabel3_DIR=../openbabel/build ../src/ -DCMAKE_BUILD_TYPE=Debug;\
 	make -j$$(nproc)
 	# Sets up all the cmake details, so that usage is as simple as
 	# `bin/sbu MOF.cif` and re-compilation is as easy as `make exe`

--- a/openbabel/include/openbabel/obutil.h
+++ b/openbabel/include/openbabel/obutil.h
@@ -35,6 +35,8 @@ GNU General Public License for more details.
 #include <time.h>
 #endif
 #endif
+// Include C++ version for clock() and CLOCKS_PER_SEC (required for GCC 12+ with C++17)
+#include <ctime>
 
 #include <math.h>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,17 @@ cmake_minimum_required(VERSION 3.11)
 # Name of your project
 project(sbu)
 
+# This block prints the compiler version to the output logs so you can debug issues.
+message(STATUS "-----------------------------------------------------------")
+message(STATUS "  Compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+message(STATUS "  Binary:   ${CMAKE_CXX_COMPILER}")
+message(STATUS "-----------------------------------------------------------")
+
+# Optional: Warn if the compiler is too old (e.g., older than GCC 9)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+    message(WARNING "You are using an older GCC version (${CMAKE_CXX_COMPILER_VERSION}). Recommended: GCC 9+")
+endif()
+
 # Require C++17 across all platforms (Linux, Windows, Mac)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,15 +10,18 @@ cmake_minimum_required(VERSION 3.11)
 
 # Name of your project
 project(sbu)
+
+# Require C++17 across all platforms (Linux, Windows, Mac)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# Enable compiler-specific extensions (e.g., gnu++17 on Linux)
+set(CMAKE_CXX_EXTENSIONS ON)
+
 # Create a list of source files (easier to maintain)
 # set(sources sbu.cpp)
 # Set the name for the executable
 # set(executable_target sbu)
 # Use a loop like openbabel/tools/CMakeLists.txt
-
-# GoogleTest requires at least C++14
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (BUILD_TESTING)
     enable_testing()


### PR DESCRIPTION
This PR resolves issue #35 and fixes compilation errors on systems where GCC 11 is not explicitly available.

# Summary of changes:

**Build System & CI**
* **Removed Hardcoded Compiler Versions:** Replaced explicit `gcc-11` and `g++-11` calls in the `Makefile` with `$(CC)` and `$(CXX)` variables. This resolves CI failures across environments with varying compiler versions (including newer runners like Ubuntu 24.04) and allows the build to use the system's default compiler.
* **Upgraded to C++17:** Updated `src/CMakeLists.txt` to require C++17 (previously C++14), enabling modern language features (particularly related to `compare.cpp`)
* **Enhanced Debugging:** Added a reporting block to `CMakeLists.txt` that prints the active compiler ID and version during configuration.
* **New Utility Target:** Added a `clean-init` target to the `Makefile` to quickly remove build artifacts and installed binaries.

**Code Compatibility**
* **Fixed GCC 12+ Compilation:** Added `#include <ctime>` to `openbabel/obutil.h`. This resolves "missing type" errors on newer GCC versions (12/13+) where implicit header includes have been removed.